### PR TITLE
fixing defect with query string duplication of prepending '?' where p…

### DIFF
--- a/src/Eowin.AzureServiceBusRelay.Server/DispatcherService.cs
+++ b/src/Eowin.AzureServiceBusRelay.Server/DispatcherService.cs
@@ -100,7 +100,7 @@ namespace Eowin.AzureServiceBusRelay.Server
             var reqUri = incomingRequest.UriTemplateMatch.RequestUri;
             ctx.Request.Scheme = reqUri.Scheme;
             ctx.Request.Path = new PathString(reqUri.AbsolutePath);
-            ctx.Request.QueryString = new QueryString(reqUri.Query);
+            ctx.Request.QueryString = new QueryString(reqUri.Query.TrimStart('?'));
 
             var onSendingHeaders =
                 new Action<Action<object>, object>((h, o) => onSendingHeadersHandler.Add(Tuple.Create(h, o)));


### PR DESCRIPTION
This bug will interfere with parameter/model object deserialization in WebAPI as a "??" will cause the first variable following to be ignored.
